### PR TITLE
Improved AssertMoveDtoEquality if move pieces are null

### DIFF
--- a/Backend/Source/Stratego.AppLogic.Tests/GameServiceTests.cs
+++ b/Backend/Source/Stratego.AppLogic.Tests/GameServiceTests.cs
@@ -240,7 +240,7 @@ namespace Stratego.AppLogic.Tests
                 "The move dto returned is not derived properly from the 'LastMove' of the game. Unexpected 'From' value.");
             Assert.That(dto.PlayerId, Is.EqualTo(move.PlayerId),
                 "The move dto returned is not derived properly from the 'LastMove' of the game. Unexpected 'PlayerId' value.");
-            Assert.That(dto.Piece.Id, Is.EqualTo(move.Piece.Id),
+            Assert.That(dto.Piece?.Id, Is.EqualTo(move.Piece?.Id),
                 "The move dto returned is not derived properly from the 'LastMove' of the game. Unexpected 'Piece' value.");
             Assert.That(dto.TargetPiece?.Id, Is.EqualTo(move.TargetPiece?.Id),
                 "The move dto returned is not derived properly from the 'LastMove' of the game. Unexpected 'TargetPiece' value.");


### PR DESCRIPTION
2 of my tests were red because of a NullReferenceException because the piece in the move was null. For safety, I added two null-safe navigators to not throw a NullReferenceException if both pieces in the dto and the move are null.